### PR TITLE
Allow to also backup on stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV NBPLAYERS 70
 ENV UPDATEONSTART 1
 # if the server is backup when start with docker start
 ENV BACKUPONSTART 1
+# if the server should backup after stopping
+ENV BACKUPONSTOP 0
 #  branch on github for ark server tools
 ENV BRANCH master
 # Server PORT (you can't remap with docker, it doesn't work)

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,10 @@ RUN mkdir  /ark
 
 # We use the git method, because api github has a limit ;)
 RUN  git clone -b $BRANCH https://github.com/FezVrasta/ark-server-tools.git /home/steam/ark-server-tools
+
+# Current ark-server-tools version is not supported yet, so checkout older one
+RUN cd /home/steam/ark-server-tools && git checkout 0cac2ab215c9c34924afac43c033167d9e95f6f9
+
 # Install 
 WORKDIR /home/steam/ark-server-tools/tools
 RUN chmod +x install.sh 

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,14 @@ mkfifo /tmp/FIFO
 
 export TERM=linux
 
+function stop {
+	arkmanager stop
+	if [ ${BACKUPONSTOP} -eq 1 ]; then
+                echo "[Backup]"
+                arkmanager backup
+        fi
+}
+
 if [ ! -w /ark ]; then 
 	echo "[Error] Can't access ark directory. Check permissions on your mapped directory with /ark"
 	exit 1
@@ -66,8 +74,8 @@ arkmanager start
 
 # Stop server in case of signal INT or TERM
 echo "Waiting..."
-trap 'arkmanager stop;' INT
-trap 'arkmanager stop' TERM
+trap stop INT
+trap stop TERM
 
 read < /tmp/FIFO &
 wait

--- a/run.sh
+++ b/run.sh
@@ -8,11 +8,11 @@ mkfifo /tmp/FIFO
 export TERM=linux
 
 function stop {
-	arkmanager stop
 	if [ ${BACKUPONSTOP} -eq 1 ]; then
-                echo "[Backup]"
+                echo "[Backup on stop]"
                 arkmanager backup
         fi
+	arkmanager stop
 }
 
 if [ ! -w /ark ]; then 


### PR DESCRIPTION
Hi there,

first I would like to thank you for your great docker setup of ARK! This did save me a lot of trouble :-)

I want to share the savegames of my server with friends so I created a little script which looks if there is a new backup in the backups folder and creates a zip file which is then accessible via a HTTP server. This works great but the latest backup is of course always the one of the previous session. So I introduced a new environment variable BACKUPONSTOP here (defaults to 0), which does exactly what it name says. Please have a look at it and consider merging it into your branch. Thanks in advance!

Regards
Fabian
