### PR TITLE
removed unnecessary quotation marks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ ark:
   environment:
     - SESSIONNAME=Ark Docker
     - SERVERMAP=TheIsland
-    - SERVERPASSWORD="" 
+    - SERVERPASSWORD=
     - ADMINPASSWORD=adminpassword
     - BACKUPONSTART=1
     - UPDATEONSTART=1


### PR DESCRIPTION
If you use the quotation marks in the docker-compose file as Server Password, they are actually part of the password. So `- SERVERPASSWORD=""` actually sets the Password to `""`